### PR TITLE
Added Float32 versions of arithmetic functions

### DIFF
--- a/src/Yeppp.jl
+++ b/src/Yeppp.jl
@@ -63,13 +63,13 @@ macro yepppfunsA_S(fname, libname, BT)
     end 
 end 
 
+## == Float64 == ##
 @yepppfunsAA_A add! "yepCore_Add_V64fV64f_V64f" Float64
 @yepppfunsAA_A multiply! "yepCore_Multiply_V64fV64f_V64f" Float64
 @yepppfunsAA_A subtract! "yepCore_Subtract_V64fV64f_V64f" Float64
 @yepppfunsAA_A max! "yepCore_Max_V64fV64f_V64f" Float64
 @yepppfunsAA_A min! "yepCore_Min_V64fV64f_V64f" Float64
 
-# @yepppfunsA_A negate "yepCore_Negate_IV64f_IV64f Float64
 @yepppfunsA_A log! "yepMath_Log_V64f_V64f" Float64
 @yepppfunsA_A exp! "yepMath_Exp_V64f_V64f" Float64
 @yepppfunsA_A sin! "yepMath_Sin_V64f_V64f" Float64
@@ -79,6 +79,16 @@ end
 @yepppfunsA_S sum "yepCore_Sum_V64f_S64f" Float64
 @yepppfunsA_S sumabs "yepCore_SumAbs_V64f_S64f" Float64
 @yepppfunsA_S sumabs2 "yepCore_SumSquares_V64f_S64f" Float64
+
+## == Float32 == ##
+@yepppfunsAA_A add! "yepCore_Add_V32fV32f_V32f" Float32
+@yepppfunsAA_A multiply! "yepCore_Multiply_V32fV32f_V32f" Float32
+@yepppfunsAA_A subtract! "yepCore_Subtract_V32fV32f_V32f" Float32
+@yepppfunsAA_A max! "yepCore_Max_V32fV32f_V32f" Float32
+@yepppfunsAA_A min! "yepCore_Min_V32fV32f_V32f" Float32
+
+@yepppfunsA_S sum "yepCore_Sum_V32f_S32f" Float32
+@yepppfunsA_S sumabs2 "yepCore_SumSquares_V32f_S32f" Float32
 
 """
     dot(x::Vector{Float64}, y::Vector{Float64})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,32 @@
 using Yeppp
 using Base.Test
 
-# write your own tests here
+for T in (Float32, Float64)
+    x::Vector{T} = rand(1000)
+    y::Vector{T} = rand(1000)
+    z::Vector{T} = randn(1000)
+    res::Vector{T} = rand(1000)
+
+    @test Yeppp.add!(res, x, y) == x .+ y
+    @test Yeppp.multiply!(res, x, y) == x .* y
+    @test Yeppp.subtract!(res, x, y) == x .- y
+    @test Yeppp.multiply(x, y) == x .* y
+    @test Yeppp.subtract(x, y) == x .- y
+    @test Yeppp.min!(res, x, y) == min(x, y)
+    @test Yeppp.max!(res, x, y) == max(x, y)
+    @test Yeppp.min(x, y) == min(x, y)
+    @test Yeppp.max(x, y) == max(x, y)
+
+    @test_approx_eq Yeppp.sum(x) sum(x)
+    @test_approx_eq Yeppp.sumabs2(x) sumabs2(x)
+    @test_approx_eq Yeppp.dot(x, y) dot(x, y)
+
+end
+
 x = rand(1000)
 y = rand(1000)
 z = randn(1000)
 res = rand(1000)
-
-@test Yeppp.add!(res, x, y) == x .+ y
-@test Yeppp.multiply!(res, x, y) == x .* y 
-@test Yeppp.subtract!(res, x, y) == x .- y 
-@test Yeppp.multiply(x, y) == x .* y 
-@test Yeppp.subtract(x, y) == x .- y 
-@test Yeppp.min!(res, x, y) == min(x, y)
-@test Yeppp.max!(res, x, y) == max(x, y)
-@test Yeppp.min(x, y) == min(x, y)
-@test Yeppp.max(x, y) == max(x, y)
-
 
 @test_approx_eq Yeppp.exp!(res, x) exp(x)
 @test_approx_eq Yeppp.log!(res, x) log(x)
@@ -28,8 +38,3 @@ res = rand(1000)
 @test_approx_eq Yeppp.sumabs(x) sumabs(x)
 @test_approx_eq Yeppp.sumabs2(x) sumabs2(x)
 
-for T in (Float32, Float64)
-    xx::Vector{T} = rand(1000)
-    yy::Vector{T} = rand(1000)
-    @test_approx_eq Yeppp.dot(xx, yy) dot(xx, yy)
-end


### PR DESCRIPTION
I added Float32 support for the Yeppp functions that support it (only a small number actually support non-Float64 values). I also changed the test suite so that it tests both the Float32 and Float64 versions. 
1. add
2. subtract
3. multiply
4. max
5. min
6. sum
7. sumabs2
