### PR TITLE
Float32 version of dot()

### DIFF
--- a/src/Yeppp.jl
+++ b/src/Yeppp.jl
@@ -95,6 +95,20 @@ function dot(x::Vector{Float64}, y::Vector{Float64})
 end
 
 """
+    dot(x::Vector{Float32}, y::Vector{Float32})
+
+Compute the dot product of x and y.
+"""
+function dot(x::Vector{Float32}, y::Vector{Float32})
+    n = length(x)
+    assert(n == length(y))
+    dotproduct = Array(Float32, 1)
+    const status = ccall( (:yepCore_DotProduct_V32fV32f_S32f, libyeppp), Cint, (Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Culong), x, y, dotproduct, n)
+    status != 0 && error("yepCore_DotProduct_V32fV32f_S32f: error: ", status)
+    dotproduct[1]
+end
+
+"""
     max(x, y)
 
 Compares the vectors `x` and `y` and return the element wise maxima.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,4 +28,8 @@ res = rand(1000)
 @test_approx_eq Yeppp.sumabs(x) sumabs(x)
 @test_approx_eq Yeppp.sumabs2(x) sumabs2(x)
 
-@test_approx_eq Yeppp.dot(x, y) dot(x, y)
+for T in (Float32, Float64)
+    xx::Vector{T} = rand(1000)
+    yy::Vector{T} = rand(1000)
+    @test_approx_eq Yeppp.dot(xx, yy) dot(xx, yy)
+end


### PR DESCRIPTION
I found myself using the Float32 version of `dot()`. This PR contains a Float32 `dot()` implementation as well as a test for both types. 
