### PR TITLE
Added support for views and subarrays, updated tests, added sumabs for Float32

### DIFF
--- a/src/Yeppp.jl
+++ b/src/Yeppp.jl
@@ -21,12 +21,12 @@ function release()
     status != 0 && error("yepLibrary_Release: error: ", status)
 end
 
-checkcontigous(A::DenseArray) = true
+_iscontiguous(A::DenseArray) = true
 # Fallback
-checkcontigous(A::StridedArray) = false
+_iscontiguous(A::StridedArray) = false
 # Cases we can verify
-checkcontigous(A::SubArray) = Base.iscontiguous(A)
-checkcontigous(A::StridedVector) = stride(A,1) == 1
+_iscontiguous(A::SubArray) = Base.iscontiguous(A)
+_iscontiguous(A::StridedVector) = stride(A,1) == 1
 
 macro yepppfunsAA_A(fname, libname, BT)
     errorname = libname * ": error: "
@@ -36,7 +36,7 @@ macro yepppfunsAA_A(fname, libname, BT)
             n = length(x)
             @assert(n == length(y) == length(res))
             @assert !Base.has_offset_axes(res, x, y)
-            @assert checkcontigous(res) && checkcontigous(x) && checkcontigous(y) "could not verify that arguments are contigous is memory"
+            @assert _iscontiguous(res) && _iscontiguous(x) && _iscontiguous(y) "could not verify that arguments are contigous is memory"
 
             status = ccall( ($(libname), libyeppp), Cint, (Ptr{$(BT)}, Ptr{$(BT)}, Ptr{$(BT)}, Culong), x, y, res, n)
             status != 0 && error($(errorname), status)
@@ -53,7 +53,7 @@ macro yepppfunsA_A(fname, libname, BT)
             n = length(x)
             @assert(n == length(res))
             @assert !Base.has_offset_axes(res, x)
-            @assert checkcontigous(res) && checkcontigous(x) "could not verify that arguments are contigous is memory"
+            @assert _iscontiguous(res) && _iscontiguous(x) "could not verify that arguments are contigous is memory"
 
             status = ccall( ($(libname), libyeppp), Cint, (Ptr{$(BT)}, Ptr{$(BT)}, Culong), x, res, n)
             status != 0 && error($(errorname), status)
@@ -69,7 +69,7 @@ macro yepppfunsA_S(fname, libname, BT)
         function $(fname)(x::Union{DenseArray{$(BT)},StridedArray{$(BT)}})
             n = length(x)
             @assert !Base.has_offset_axes(x)
-            @assert checkcontigous(x) "could not verify that arguments are contigous is memory"
+            @assert _iscontiguous(x) "could not verify that arguments are contigous is memory"
             res = Ref{$BT}()
             status = ccall( ($(libname), libyeppp), Cint, (Ptr{$(BT)}, Ptr{$(BT)}, Culong), x, res, n)
             status != 0 && error($(errorname), status)
@@ -115,7 +115,7 @@ function dot(x::Union{DenseVector{Float64},StridedVector{Float64}}, y::Union{Den
     n = length(x)
     @assert(n == length(y))
     @assert !Base.has_offset_axes(x, y)
-    @assert checkcontigous(x) && checkcontigous(y)
+    @assert _iscontiguous(x) && _iscontiguous(y)
 
     dotproduct = Ref{Float64}()
     status = ccall( (:yepCore_DotProduct_V64fV64f_S64f, libyeppp), Cint, (Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Culong), x, y, dotproduct, n)
@@ -132,7 +132,7 @@ function dot(x::Union{DenseVector{Float32},StridedVector{Float32}}, y::Union{Den
     n = length(x)
     @assert(n == length(y))
     @assert !Base.has_offset_axes(x, y)
-    @assert checkcontigous(x) && checkcontigous(y)
+    @assert _iscontiguous(x) && _iscontiguous(y)
 
     dotproduct = Ref{Float32}()
     status = ccall( (:yepCore_DotProduct_V32fV32f_S32f, libyeppp), Cint, (Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Culong), x, y, dotproduct, n)
@@ -159,7 +159,7 @@ function evalpoly!(res::Union{DenseArray{Float64},StridedVector{Float64}}, coef:
     arraysize = length(x)
     @assert(arraysize == length(res))
     @assert !Base.has_offset_axes(res, coef, x)
-    @assert checkcontigous(res) && checkcontigous(coef) && checkcontigous(x)
+    @assert _iscontiguous(res) && _iscontiguous(coef) && _iscontiguous(x)
 
     status = ccall( (:yepMath_EvaluatePolynomial_V64fV64f_V64f, libyeppp), Cint, (Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Culong, Culong), coef, x, res, n, arraysize)
     status != 0 && error("yepMath_EvaluatePolynomial_V64fV64f_V64f: error: ", status)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,38 +3,99 @@ using Test
 import LinearAlgebra
 
 for T in (Float32, Float64)
-    x::Vector{T} = rand(1000)
-    y::Vector{T} = rand(1000)
-    z::Vector{T} = randn(1000)
-    res::Vector{T} = rand(1000)
+    for vecfun in (v -> Vector{T}(v),
+                   v -> view(Vector{T}(v), 100:700),
+                   v -> reshape(Vector{T}(v), 50,20),
+                   v -> view(reshape(Vector{T}(v), 50,20), 10:50, 5),
+                   v -> SubArray(reshape(Vector{T}(v), 50,20), (10:50, 5)))
+        x = vecfun(rand(1000))
+        y = vecfun(rand(1000))
+        z = vecfun(randn(1000))
+        res = vecfun(rand(1000))
 
-    @test Yeppp.add!(res, x, y) == x .+ y
-    @test Yeppp.multiply!(res, x, y) == x .* y
-    @test Yeppp.subtract!(res, x, y) == x .- y
-    @test Yeppp.multiply(x, y) == x .* y
-    @test Yeppp.subtract(x, y) == x .- y
-    @test Yeppp.min!(res, x, y) == min.(x, y)
-    @test Yeppp.max!(res, x, y) == max.(x, y)
-    @test Yeppp.min(x, y) == min.(x, y)
-    @test Yeppp.max(x, y) == max.(x, y)
+        @test Yeppp.add!(res, x, y) == x .+ y
+        @test Yeppp.multiply!(res, x, y) == x .* y
+        @test Yeppp.subtract!(res, x, y) == x .- y
+        @test Yeppp.multiply(x, y) == x .* y
+        @test Yeppp.subtract(x, y) == x .- y
+        @test Yeppp.min!(res, x, y) == min.(x, y)
+        @test Yeppp.max!(res, x, y) == max.(x, y)
+        @test Yeppp.min(x, y) == min.(x, y)
+        @test Yeppp.max(x, y) == max.(x, y)
 
-    @test Yeppp.sum(x) ≈ sum(x)
-    @test Yeppp.sumabs2(x) ≈ sum(abs2, x)
-    @test Yeppp.dot(x, y) ≈ LinearAlgebra.dot(x, y)
-
+        @test Yeppp.sum(x) ≈ sum(x)
+        @test Yeppp.sumabs(x) ≈ sum(abs, x)
+        @test Yeppp.sumabs2(x) ≈ sum(abs2, x)
+        if ndims(x) > 1
+            @test_throws MethodError Yeppp.dot(x, y)
+        else
+            @test Yeppp.dot(x, y) ≈ LinearAlgebra.dot(x, y)
+        end
+    end
 end
 
-x = rand(1000)
-y = rand(1000)
-z = randn(1000)
-res = rand(1000)
+for T in (Float32, Float64)
+    for vecfun in (v -> view(Vector{T}(v), 1:2:500),
+                   v -> view(reshape(Vector{T}(v), 50,20), 10:2:50, 5),
+                   v -> view(reshape(Vector{T}(v), 50,20), 5, :),
+                   v -> SubArray(reshape(Vector{T}(v), 50,20), (10:50, 5:10)),
+                   v -> SubArray(reshape(Vector{T}(v), 50,20), (10:2:50, 1)))
+        x = vecfun(rand(1000))
+        y = vecfun(rand(1000))
+        z = vecfun(randn(1000))
+        res = vecfun(rand(1000))
 
-@test Yeppp.exp!(res, x) ≈ exp.(x)
-@test Yeppp.log!(res, x) ≈ log.(x)
-@test Yeppp.sin!(res, x) ≈ sin.(x)
-@test Yeppp.cos!(res, x) ≈ cos.(x)
-@test Yeppp.tan!(res, x) ≈ tan.(x)
+        @test_throws AssertionError Yeppp.add!(res, x, y)
+        @test_throws AssertionError Yeppp.multiply!(res, x, y)
+        @test_throws AssertionError Yeppp.subtract!(res, x, y)
+        @test_throws AssertionError Yeppp.multiply(x, y)
+        @test_throws AssertionError Yeppp.subtract(x, y)
+        @test_throws AssertionError Yeppp.min!(res, x, y)
+        @test_throws AssertionError Yeppp.max!(res, x, y)
+        @test_throws AssertionError Yeppp.min(x, y)
+        @test_throws AssertionError Yeppp.max(x, y)
 
-@test Yeppp.sum(x) ≈ sum(x)
-@test Yeppp.sumabs(x) ≈ sum(abs, x)
-@test Yeppp.sumabs2(x) ≈ sum(abs2, x)
+        @test_throws AssertionError Yeppp.sum(x)
+        @test_throws AssertionError Yeppp.sumabs(x)
+        @test_throws AssertionError Yeppp.sumabs2(x)
+        if ndims(x) > 1
+            @test_throws MethodError Yeppp.dot(x, y)
+        else
+            @test_throws AssertionError Yeppp.dot(x, y)
+        end
+    end
+end
+
+for vecfun in (v -> v,
+               v -> view(v, 100:700),
+               v -> reshape(v, 50,20),
+               v -> view(reshape(v, 50,20), 10:50, 5),
+               v -> SubArray(reshape(v, 50,20), (10:50, 5)))
+    x = vecfun(rand(1000))
+    y = vecfun(rand(1000))
+    z = vecfun(randn(1000))
+    res = vecfun(rand(1000))
+
+    @test Yeppp.exp!(res, x) ≈ exp.(x)
+    @test Yeppp.log!(res, x) ≈ log.(x)
+    @test Yeppp.sin!(res, x) ≈ sin.(x)
+    @test Yeppp.cos!(res, x) ≈ cos.(x)
+    @test Yeppp.tan!(res, x) ≈ tan.(x)
+end
+
+for vecfun in (v -> view(v, 1:2:500),
+               v -> view(reshape(v, 50,20), 10:2:50, 5),
+               v -> view(reshape(v, 50,20), 5, :),
+               v -> SubArray(reshape(v, 50,20), (10:50, 5:10)),
+               v -> SubArray(reshape(v, 50,20), (10:2:50, 1)))
+    x = vecfun(rand(1000))
+    y = vecfun(rand(1000))
+    z = vecfun(randn(1000))
+    res = vecfun(rand(1000))
+
+    @test_throws AssertionError Yeppp.exp!(res, x)
+    @test_throws AssertionError Yeppp.log!(res, x)
+    @test_throws AssertionError Yeppp.sin!(res, x)
+    @test_throws AssertionError Yeppp.cos!(res, x)
+    @test_throws AssertionError Yeppp.tan!(res, x)
+end


### PR DESCRIPTION
I have found this package quite useful, but it seems to lack support for common types such as views of arrays. Hope you like it.

Notable things:
* I added `_iscontiguous` to verify is a `StridedArray` is contiguous, and a fallback for `StridedArray` to false, there are probably better ways to check this? Maybe someone with better knowledge of the julia internals can comment on this?

* Removed the argument specification `Array` on `add`  and `subtract`. They were inconsistent with the other wrappers. Maybe they should all be `Any` as most of them were, or something a bit more stringent?

 * Added `sumabs` for `Float32`. I was not able to find the source to verify that this should work, but it seems to pass the tests.

* Kept the requirement on arguments being vectors for `dot`, this is not the case in Base, so maybe it can be relaxed (but this is an orthogonal problem)

* Updated `evalpoly.jl` to work on julia 1.0, although this code is not run automatically on tests (could also be separate issue)

EDIT: Tests fails on osx, I am not sure what is going on here, is it a build problem? Last test was run 8 months ago.